### PR TITLE
#34 - Correção do erro do segfault atributo não implementado

### DIFF
--- a/src/AttributeInfo.cpp
+++ b/src/AttributeInfo.cpp
@@ -163,8 +163,11 @@ Attributes::Attributes(std::ifstream& f, u2 attributesCount, ConstantPool cpt){
 			LocalVariableTable *lvt = new LocalVariableTable(idx, f, name);
 			push_back(lvt);
 		}	
-		else
-			std::cout << "Atributo não implementado!" << std::endl;
+		else {
+			u4 lentgh = r4(f);
+			f.seekg(lentgh + f.tellg());
+			std::cout << "Atributo não implementado: " + name << std::endl;
+		}
 	}
 }
 


### PR DESCRIPTION
Agora é possível executar os arquivos Jogador.class, Die.class e Harmonica.class sem erro de segmentação.

Closes #34 