### PR TITLE
Alterações para as pastas obj e Output estarem no GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ main
 .vscode/*
 
 # Objects folder
-obj/*
+obj/*.o
 
 # Resultados
 Output/*.txt

--- a/Output/.dontIgnore
+++ b/Output/.dontIgnore
@@ -1,0 +1,1 @@
+Do not ignore this folder

--- a/obj/.dontIgnore
+++ b/obj/.dontIgnore
@@ -1,0 +1,1 @@
+Git, don't ignore the folder, just the files


### PR DESCRIPTION
A ideia seria não ter que lidar com problemas com a função **mkdir** (depreciada no Windows) e com o fato de ter que existir a pasta *obj*